### PR TITLE
fix: create a flutter folder for deprecated v0 examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@
 - supabase-flutter-v1 examples
 
 # Deprecated
-- supabase-js-v1 - Supabase
+- supabase-js-v1 - examples
+- supabase-flutter-v0 examples
 ```
 
 


### PR DESCRIPTION
Should we separate out the flutter examples for deprecated ones as well?