### PR TITLE
fix: react README change

### DIFF
--- a/supabase-js-v2/user-management/react-user-management/README.md
+++ b/supabase-js-v2/user-management/react-user-management/README.md
@@ -50,7 +50,7 @@ Populate this file with your URL and Key.
 
 ### 5. Run the application
 
-Run the application: `npm run dev`. Open your browser to `https://localhost:3000/` and you are ready to go 🚀.
+Run the application: `npm run start`. Open your browser to `https://localhost:3000/` and you are ready to go 🚀.
 
 ## Supabase details
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

The [react user management](https://github.com/supabase/examples/tree/main/supabase-js-v2/user-management/react-user-management) has `npm run dev` command to start a dev server which will fail

## What is the new behavior?

Updated to use `npm run start` which creates a local server.
